### PR TITLE
Fixed wrong translation

### DIFF
--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -149,8 +149,8 @@
     <string name="pref_accent">Segui colore di sistema</string>
     <string name="pref_accent_on">È in uso il colore predefinito dell’app</string>
     <string name="pref_accent_off">È in uso il colore di sistema</string>
-    <string name="create_all">Crea tutti i colori</string>
-    <string name="create_all_summary">Crea tutti i colori dei marchi, quelli predefiniti e quelli dello sfondo</string>
+    <string name="create_all">Crea più colori per volta</string>
+    <string name="create_all_summary">Crea più colori dei marchi, predefiniti e dello sfondo per volta</string>
     <string name="select_all">Seleziona tutto</string>
     <string name="deselect_all">Deseleziona tutto</string>
     <string name="create_selected">Crea colori selezionati</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -22,7 +22,7 @@
     <string name="dark">Scuro</string>
     <string name="info">Informazioni</string>
     <string name="separate_accent_summary_off">Lo stesso colore verrà usato per il tema chiaro e per quello scuro</string>
-    <string name="separate_accent_summary_on">Ora è possibile utilizzare colori diversi per il tema chiaro e quello scuro</string>
+    <string name="separate_accent_summary_on">Ora è possibile utilizzare colori diversi per il tema chiaro e per quello scuro</string>
     <string name="hue">Tonalità</string>
     <string name="saturation">Saturazione</string>
     <string name="lightness">Luminosità</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -22,7 +22,7 @@
     <string name="dark">Scuro</string>
     <string name="info">Informazioni</string>
     <string name="separate_accent_summary_off">Lo stesso colore verrà usato per il tema chiaro e per quello scuro</string>
-    <string name="separate_accent_summary_on">Ora è possibile utilizzare colori diversi per i temi chiari e quelli scuri</string>
+    <string name="separate_accent_summary_on">Ora è possibile utilizzare colori diversi per il tema chiaro e quello scuro</string>
     <string name="hue">Tonalità</string>
     <string name="saturation">Saturazione</string>
     <string name="lightness">Luminosità</string>


### PR DESCRIPTION
I don't know why but I translated "Create multiple accents" as "Create all accents" (maybe it was from an earlier version?)